### PR TITLE
fix handing a newline characters in the subscribeReply string

### DIFF
--- a/config/wx_oa.go
+++ b/config/wx_oa.go
@@ -38,7 +38,8 @@ func GetWxAppSecret() string {
 	return os.Getenv(Wx_App_Secret_key)
 }
 func GetWxSubscribeReply() string {
-	return os.Getenv(Wx_Subscribe_Reply_key)
+	subscribeMsg := os.Getenv(Wx_Subscribe_Reply_key)
+	return strings.ReplaceAll(subscribeMsg, "\\n", "\n")
 }
 func GetWxHelpReply() string {
 	helpMsg := os.Getenv(Wx_Help_Reply_key)


### PR DESCRIPTION
如题，没有对订阅字符串进行换行符处理，就会尴尬如斯：

![ccc75b7791ae2e6b882f2e05f6dd15b](https://github.com/QAbot-zh/aiwechat-vercel/assets/40236765/8f72a54d-e999-42bb-98d5-40398694dac2)
